### PR TITLE
MNT: add * to setuptools.packages.find.include

### DIFF
--- a/setup_to_pyproject.py
+++ b/setup_to_pyproject.py
@@ -137,7 +137,7 @@ def convert_to_pyproject_toml(
     import_name = project["name"].replace("-", "_")
 
     # find_packages() replacement:
-    tool["setuptools"]["packages"]["find"]["include"] = [import_name]
+    tool["setuptools"]["packages"]["find"]["include"] = [import_name + '*']
 
     # Throw away:
     # packages


### PR DESCRIPTION
Addition of * to the `[tool.setuptools.packages.find]` section of pyproject.toml must be done in the `setup_to_pyproject.py` script, since it replaces the entry with the package name.  Modifying the cookiecutter isn't sufficient here.