### PR TITLE
FIX: repo name can have dashes/hyphens/-, import name cannot

### DIFF
--- a/update_python_repository.py
+++ b/update_python_repository.py
@@ -778,8 +778,8 @@ def get_repo_name(root: pathlib.Path) -> str:
 def get_template_defaults(root: pathlib.Path) -> dict[str, Any]:
     cookiecutter = CookiecutterSettings()
     cookiecutter.project_name = get_repo_name(root)
-    cookiecutter.repo_name = cookiecutter.project_name.replace("-", "_")
-    cookiecutter.import_name = cookiecutter.repo_name
+    cookiecutter.repo_name = cookiecutter.project_name
+    cookiecutter.import_name = cookiecutter.repo_name.replace("-", "_")
     return {
         "cookiecutter": cookiecutter,
     }


### PR DESCRIPTION
* A small source of confusion in ads-async
* It's possible we mistakenly merged some code with this bug in it