### PR TITLE
MNT: bump Python cookiecutter to latest (incl. secrets propagation)

### DIFF
--- a/setup_to_pyproject.py
+++ b/setup_to_pyproject.py
@@ -62,9 +62,9 @@ def pick_file(
     option = find_file_by_options(path, options)
     if option is not None:
         dest[key] = option.name
-    else:
-        dest.pop(key)
-    return option.name
+        return option.name
+    dest.pop(key)
+    return None
 
 
 def set_if_available(


### PR DESCRIPTION
* Secrets propagation
* Missing pytest-cov additions
* Updated `.version` module / setuptools-scm version number shim we vendor with each library
* Including some additional fix which I'm sure is good but I don't recall the full reasons to