### PR TITLE
MNT: add gh-pages and * branch protection rules, extend AddBranchProtection options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,45 @@
+===============================
+pcds-python-migration-tools
+===============================
+
+Usage
+-----
+1. Clone the repository to migrate and make a new branch
+
+    ::
+
+        $ git clone https://github.com/pcdshub/my-repo-name-here
+        $ cd my-repo-name-here
+        $ git checkout -b ref_update_repository
+
+2. Clone the migration tools in your home directory
+
+    ::
+
+        $ git clone https://github.com/pcdshub/pcds-python-migration-tools
+
+3. Perform a dry-run update of the repository with
+
+    ::
+
+        $ cd pcds-python-migration-tools
+        $ python update_repository.py /path/to/repository
+
+4. Review the updates that are proposed. Assuming all looks good, add `--write` to the arguments and re-run update_repository:
+
+    ::
+
+        $ python update_repository.py --write /path/to/repository
+
+5. If you find that the update performed something incorrectly or incompletely, you should manually fix it at this point.
+
+    ::
+
+        $ cd /path/to/repository
+        $ pre-commit run --all-files
+
+6. If you find that the update failed for some reason, please let the PD team know.
+If you want to revert your branch and try again, you can destructively reset your branch to the state of the master branch by way of ``git reset --hard origin/master``
+(Warning: Make sure you followed the above step and are on a branch specifically for migration purposes!).
+
+

--- a/graphql/branch_protection.graphql
+++ b/graphql/branch_protection.graphql
@@ -44,17 +44,20 @@ mutation addBranchProtection(
     $requiredStatusChecks:[String!],
     $allowsDeletions:Boolean!,
     $allowsForcePushes:Boolean!,
+    $blocksCreations:Boolean!,
     $dismissesStaleReviews:Boolean!,
     $isAdminEnforced:Boolean!,
     $requiresApprovingReviews:Boolean!,
     $requiredApprovingReviewCount:Int!,
     $requiresCodeOwnerReviews:Boolean!,
     $requiresStatusChecks:Boolean!,
+    $restrictsPushes:Boolean!,
     $restrictsReviewDismissals:Boolean!,
 ) {
   createBranchProtectionRule(input: {
     allowsDeletions: $allowsDeletions
     allowsForcePushes: $allowsForcePushes
+    blocksCreations: $blocksCreations
     dismissesStaleReviews: $dismissesStaleReviews
     isAdminEnforced: $isAdminEnforced
     pattern: $branchPattern
@@ -64,6 +67,7 @@ mutation addBranchProtection(
     requiresCodeOwnerReviews: $requiresCodeOwnerReviews
     requiredStatusCheckContexts:$requiredStatusChecks
     requiresStatusChecks: $requiresStatusChecks
+    restrictsPushes: $restrictsPushes
     restrictsReviewDismissals: $restrictsReviewDismissals
   }) {
     branchProtectionRule {

--- a/update_github_settings.py
+++ b/update_github_settings.py
@@ -208,7 +208,7 @@ class BranchProtection(Serializable):
         default=False, metadata=alias("restrictsReviewDismissals")
     )
     dismisses_stale_reviews: bool = field(
-        default=False, metadata=alias("dismissesStaleReviews")
+        default=True, metadata=alias("dismissesStaleReviews")
     )
     pattern: str = field(default="master")
 
@@ -395,12 +395,14 @@ def main(
         master_prot.required_status_checks = default_required_status_checks[repo_type]
 
         gh_pages_prot = BranchProtection(pattern='gh-pages', allows_force_pushes=True,
+                                         dismisses_stale_reviews=False,
                                          required_status_checks=[],
                                          requires_status_checks=False,
                                          required_approving_review_count=0,
                                          requires_approving_reviews=False,
                                          )
         all_prot = BranchProtection(pattern='*', required_status_checks=[],
+                                    dismisses_stale_reviews=False,
                                     requires_status_checks=False,
                                     required_approving_review_count=0,
                                     requires_approving_reviews=False,


### PR DESCRIPTION
## Description
- adds `restrictsPushes` and `blocksCreation` to the graphql createBranchProtectionRule
  - `restrictsPushes` was missing from the graphql side, despite existing in python (being actually applied now changes the base "master" branch protection rule
  - 
![image](https://github.com/pcdshub/pcds-python-migration-tools/assets/35379409/a0ea56bc-2460-43e3-81c5-3e29768e9854)

- adds branch protection rules for `gh-pages` branch and `*` (restricts the creation of new branches)
  - see [pcds-ci-test-repo](https://github.com/pcdshub/pcds-ci-test-repo-python/settings/branches) 's branch protection as an example
- adds the `--write` flag to update_github_settings
- adds a readme (ripped from confluence)

## Screenshots
What an approved PR looks like for a non-admin user
![image](https://github.com/pcdshub/pcds-python-migration-tools/assets/35379409/6643ed48-5a76-49cc-9cdd-6f6ef7e2193d)
