### PR TITLE
ENH: add apply branch protections tool

### DIFF
--- a/update_branch_protections.py
+++ b/update_branch_protections.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import argparse
 import csv
+from dataclasses import dataclass, fields
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import List
 
 from update_github_settings import BranchProtection, Repository
 
@@ -23,16 +24,68 @@ all_prot = BranchProtection(pattern='*', required_status_checks=[],
                             allows_deletions=True,)
 
 
-# Map column names to protection rules
-RULE_MAP = {'master': master_protect, 'gh-pages': gh_pages_prot, 'default': all_prot}
-
-
 def str_to_bool(val: str):
     return val.lower() in ('y', 'yes', 'true')
 
 
-def parse_repo_list(repo_data_path: str) -> List[Dict[str, Any]]:
-    """ Returns {reponame: {master: bool, gh_pages: bool, all: bool}}"""
+@dataclass
+class ProtectionGroup:
+    owner: str
+    repo_name: str
+    master: bool = False
+    gh_pages: bool = False
+    default: bool = False
+
+    # Map column names to protection rules
+    RULE_MAP = {
+        'master': master_protect,
+        'gh_pages': gh_pages_prot,
+        'default': all_prot
+    }
+
+    @classmethod
+    def from_dict(cls, source: dict):
+        try:
+            flags = {f.name: str_to_bool(source[f.name]) for f in fields(cls)
+                     if f.name not in ('owner', 'repo_name')}
+        except KeyError as e:
+            print("source data malformed, aborting")
+            raise e
+
+        return cls(
+            owner=source["owner"],
+            repo_name=source["repo_name"],
+            **flags
+        )
+
+    def apply_protections(
+        self,
+        write: bool
+    ) -> None:
+        repo = Repository.from_name(owner=self.owner, repo=self.repo_name)
+
+        for prot in BranchProtection.from_repository(repo):
+            if write:
+                print("Deleting branch protection setting")
+                prot.delete()
+            else:
+                print("(dry run) Deleting branch protection setting")
+
+        rule_names = (f.name for f in fields(self)
+                      if f.name not in ('owner', 'repo_name'))
+
+        for name in rule_names:
+            if getattr(self, name, False):
+                print(f'created {name} rule for repo: {self.repo_name}')
+                if write:
+                    protection_rule = self.RULE_MAP[name]
+                    protection_rule.create(repo)
+                    print(f'-- {name} rule applied')
+                else:
+                    print('-- rule not applied')
+
+
+def parse_repo_list(repo_data_path: str) -> List[ProtectionGroup]:
     data_path = Path(repo_data_path)
     if not data_path.exists:
         print('repo data file does not exist')
@@ -40,49 +93,11 @@ def parse_repo_list(repo_data_path: str) -> List[Dict[str, Any]]:
     repo_data = []
     # Deal with extra columns
     with open(data_path, 'r') as csvfile:
-        csv_reader = csv.reader(csvfile)
+        csv_reader = csv.DictReader(csvfile)
         for row in csv_reader:
-            try:
-                repo_data.append(
-                    {'owner': row['owner'], 'repo_name': row['repo_name'],
-                     'master': str_to_bool(row['master']),
-                     'pages': str_to_bool(row['pages']),
-                     'default': str_to_bool(row['default'])}
-                )
-            except KeyError as e:
-                print('CSV File malformed, aborting')
-                raise e
-
+            data_row = ProtectionGroup.from_dict(row)
+            repo_data.append(data_row)
     return repo_data
-
-
-def apply_protections(owner: str, repo_name: str, prot_master: bool, prot_pages: bool, prot_default: bool,
-                      write: bool):
-    repo = Repository.from_name(owner=owner, repo=repo_name)
-
-    for prot in BranchProtection.from_repository(repo):
-        if write:
-            print("Deleting branch protection setting")
-            prot.delete()
-        else:
-            print("(dry run) Deleting branch protection setting")
-
-    if prot_master:
-        print(f'created master rule for repo: {repo_name}')
-        if write:
-            master_protect.create(repo)
-            print('-- master rule applied')
-    if prot_pages:
-        print(f'created gh-pages rule for repo: {repo_name}')
-        if write:
-            master_protect.create(repo)
-            print('-- pages rule applied')
-    if prot_default:
-        print(f'created default (*) rule for repo: {repo_name}')
-        if write:
-            master_protect.create(repo)
-            print('-- default (*) rule applied')
-    return
 
 
 def main(
@@ -94,22 +109,21 @@ def main(
     repo_data_path: str = "",
     write: bool = False
 ):
-    print(owner, repo_name, prot_master, prot_pages, prot_default,
-          repo_data_path, write)
-
     if repo_data_path:
         # run for each repo in list
         repo_data = parse_repo_list(repo_data_path)
-        for repo_details in repo_data:
-            apply_protections(repo_details['owner'], repo_details['repo_name'],
-                              repo_details['master'], repo_details['pages'],
-                              repo_details['default'], write=write)
+        for protection_group in repo_data:
+            protection_group.apply_protections(write=write)
+        return
+
+    if not repo_name:
         return
 
     # apply settings for a single repo
-    apply_protections(owner, repo_name, prot_master=prot_master,
-                      prot_pages=prot_pages, prot_default=prot_default,
-                      write=write)
+    protection_group = ProtectionGroup(
+        owner, repo_name, master=prot_master, gh_pages=prot_pages, default=prot_default
+    )
+    protection_group.apply_protections(write=write)
 
     return
 
@@ -124,8 +138,8 @@ def _create_argparser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser()
     # specify an owner, repo, and settings
-    parser.add_argument("owner", type=str)
-    parser.add_argument("repo_name", type=str)
+    parser.add_argument("owner", type=str, default='pcdshub', nargs='?')
+    parser.add_argument("repo_name", type=str, default='', nargs='?')
     parser.add_argument("--protect-master", action="store_true", dest='prot_master')
     parser.add_argument("--protect-pages", action="store_true", dest='prot_pages')
     parser.add_argument("--protect-default", action="store_true", dest='prot_default')

--- a/update_branch_protections.py
+++ b/update_branch_protections.py
@@ -97,7 +97,7 @@ class ProtectionGroup:
                 if name == 'master':
                     protection_rule = BranchProtection()
                     # customize status checks based on repo type
-                    check_name = self.CHECK_NAME_MAP.get(name, 'none')
+                    check_name = self.CHECK_NAME_MAP.get(self.repo_type, 'none')
                     check_list = default_required_status_checks[check_name]
                     protection_rule.required_status_checks = check_list
                 else:

--- a/update_branch_protections.py
+++ b/update_branch_protections.py
@@ -10,19 +10,24 @@ from update_github_settings import (BranchProtection, Repository,
                                     default_required_status_checks)
 
 master_protect = BranchProtection()
-gh_pages_prot = BranchProtection(pattern='gh-pages', allows_force_pushes=True,
-                                 dismisses_stale_reviews=False,
-                                 required_status_checks=[],
-                                 requires_status_checks=False,
-                                 required_approving_review_count=0,
-                                 requires_approving_reviews=False,
-                                 )
-all_prot = BranchProtection(pattern='*', required_status_checks=[],
-                            dismisses_stale_reviews=False,
-                            requires_status_checks=False,
-                            required_approving_review_count=0,
-                            requires_approving_reviews=False,
-                            allows_deletions=True,)
+gh_pages_prot = BranchProtection(
+    pattern='gh-pages',
+    allows_force_pushes=True,
+    dismisses_stale_reviews=False,
+    required_status_checks=[],
+    requires_status_checks=False,
+    required_approving_review_count=0,
+    requires_approving_reviews=False,
+)
+all_prot = BranchProtection(
+    pattern='*',
+    required_status_checks=[],
+    dismisses_stale_reviews=False,
+    requires_status_checks=False,
+    required_approving_review_count=0,
+    requires_approving_reviews=False,
+    allows_deletions=True
+)
 
 
 def str_to_bool(val: str):
@@ -77,8 +82,8 @@ class ProtectionGroup:
 
     def apply_protections(self, write: bool) -> None:
         """
-        Create a ``Repository``, delete its existing branch protections, and
-        create new branch protection settings
+        Create a ``Repository`` dataclass, coonnecting to the github repository.
+        Delete its existing branch protections and create new branch protections.
         """
         repo = Repository.from_name(owner=self.owner, repo=self.repo_name)
 
@@ -200,8 +205,8 @@ def _create_argparser() -> argparse.ArgumentParser:
     parser.add_argument("repo_name", type=str, default='', nargs='?',
                         help='Name of the repository')
     parser.add_argument("repo_type", type=str, default='Other', nargs='?',
-                        help='Type of the repository.  Should be one of '
-                             f'{list(ProtectionGroup.CHECK_NAME_MAP.keys())}')
+                        choices=list(ProtectionGroup.CHECK_NAME_MAP.keys()),
+                        help='Type of the repository.')
     parser.add_argument("--protect-master", action="store_true", dest='prot_master',
                         help="Add master protection.  This should be applied as "
                              "much as possible. This rule requires pull requests and "

--- a/update_branch_protections.py
+++ b/update_branch_protections.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Any, Dict, List
+
+from update_github_settings import BranchProtection, Repository
+
+master_protect = BranchProtection()
+gh_pages_prot = BranchProtection(pattern='gh-pages', allows_force_pushes=True,
+                                 dismisses_stale_reviews=False,
+                                 required_status_checks=[],
+                                 requires_status_checks=False,
+                                 required_approving_review_count=0,
+                                 requires_approving_reviews=False,
+                                 )
+all_prot = BranchProtection(pattern='*', required_status_checks=[],
+                            dismisses_stale_reviews=False,
+                            requires_status_checks=False,
+                            required_approving_review_count=0,
+                            requires_approving_reviews=False,
+                            allows_deletions=True,)
+
+
+# Map column names to protection rules
+RULE_MAP = {'master': master_protect, 'gh-pages': gh_pages_prot, 'default': all_prot}
+
+
+def str_to_bool(val: str):
+    return val.lower() in ('y', 'yes', 'true')
+
+
+def parse_repo_list(repo_data_path: str) -> List[Dict[str, Any]]:
+    """ Returns {reponame: {master: bool, gh_pages: bool, all: bool}}"""
+    data_path = Path(repo_data_path)
+    if not data_path.exists:
+        print('repo data file does not exist')
+        return
+    repo_data = []
+    # Deal with extra columns
+    with open(data_path, 'r') as csvfile:
+        csv_reader = csv.reader(csvfile)
+        for row in csv_reader:
+            try:
+                repo_data.append(
+                    {'owner': row['owner'], 'repo_name': row['repo_name'],
+                     'master': str_to_bool(row['master']),
+                     'pages': str_to_bool(row['pages']),
+                     'default': str_to_bool(row['default'])}
+                )
+            except KeyError as e:
+                print('CSV File malformed, aborting')
+                raise e
+
+    return repo_data
+
+
+def apply_protections(owner: str, repo_name: str, prot_master: bool, prot_pages: bool, prot_default: bool,
+                      write: bool):
+    repo = Repository.from_name(owner=owner, repo=repo_name)
+
+    for prot in BranchProtection.from_repository(repo):
+        if write:
+            print("Deleting branch protection setting")
+            prot.delete()
+        else:
+            print("(dry run) Deleting branch protection setting")
+
+    if prot_master:
+        print(f'created master rule for repo: {repo_name}')
+        if write:
+            master_protect.create(repo)
+            print('-- master rule applied')
+    if prot_pages:
+        print(f'created gh-pages rule for repo: {repo_name}')
+        if write:
+            master_protect.create(repo)
+            print('-- pages rule applied')
+    if prot_default:
+        print(f'created default (*) rule for repo: {repo_name}')
+        if write:
+            master_protect.create(repo)
+            print('-- default (*) rule applied')
+    return
+
+
+def main(
+    owner: str = "pcdshub",
+    repo_name: str = "",
+    prot_master: bool = False,
+    prot_pages: bool = False,
+    prot_default: bool = False,
+    repo_data_path: str = "",
+    write: bool = False
+):
+    print(owner, repo_name, prot_master, prot_pages, prot_default,
+          repo_data_path, write)
+
+    if repo_data_path:
+        # run for each repo in list
+        repo_data = parse_repo_list(repo_data_path)
+        for repo_details in repo_data:
+            apply_protections(repo_details['owner'], repo_details['repo_name'],
+                              repo_details['master'], repo_details['pages'],
+                              repo_details['default'], write=write)
+        return
+
+    # apply settings for a single repo
+    apply_protections(owner, repo_name, prot_master=prot_master,
+                      prot_pages=prot_pages, prot_default=prot_default,
+                      write=write)
+
+    return
+
+
+def _create_argparser() -> argparse.ArgumentParser:
+    """
+    Create an ArgumentParser for update_branch_protections
+
+    Returns
+    -------
+    argparse.ArgumentParser
+    """
+    parser = argparse.ArgumentParser()
+    # specify an owner, repo, and settings
+    parser.add_argument("owner", type=str)
+    parser.add_argument("repo_name", type=str)
+    parser.add_argument("--protect-master", action="store_true", dest='prot_master')
+    parser.add_argument("--protect-pages", action="store_true", dest='prot_pages')
+    parser.add_argument("--protect-default", action="store_true", dest='prot_default')
+
+    # Optionally specify everything at once
+    parser.add_argument("--repo-data-path", type=str, dest='repo_data_path',
+                        help='Path to repo data csv.  Expects columns for: '
+                             '[orgname, reponame, apply_master, apply_pages, '
+                             'apply_default]')
+
+    parser.add_argument("--write", action="store_true", dest="write")
+
+    return parser
+
+
+def _main(args=None):
+    """CLI entrypoint."""
+    parser = _create_argparser()
+    return main(**vars(parser.parse_args(args=args)))
+
+
+if __name__ == "__main__":
+    _main()

--- a/update_branch_protections.py
+++ b/update_branch_protections.py
@@ -65,7 +65,7 @@ class ProtectionGroup:
             flags = {f.name: str_to_bool(source[f.name]) for f in fields(cls)
                      if f.name not in ('owner', 'repo_name', 'repo_type')}
         except KeyError as e:
-            print("source data malformed, aborting")
+            print("source data malformed, aborting data=", source)
             raise e
 
         return cls(
@@ -195,7 +195,7 @@ def _create_argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     # specify an owner, repo, and settings
     parser.add_argument("owner", type=str, default='pcdshub', nargs='?',
-                        help='Organization or ownder of the repository, "pcdshub"'
+                        help='Organization or owner of the repository, "pcdshub"'
                              'by default')
     parser.add_argument("repo_name", type=str, default='', nargs='?',
                         help='Name of the repository')

--- a/update_github_settings.py
+++ b/update_github_settings.py
@@ -39,6 +39,7 @@ default_required_status_checks = {
         # "standard / Syntax check / Experimental Syntax Check",
         # "standard / pre-commit checks / pre-commit",
     ],
+    "none": []
 }
 
 


### PR DESCRIPTION
## Description
- adds a script to apply branch protections, either for a specific repo or for multiple repos via a csv
- attempts to make this extensible.  Adding a new branch protection rule should only involve modifying the `ProtectionGroup` dataclass and adding a flag in the argparser.
  - some care must be taken to make sure keys in the csv match the dataclass, but something had to match somewhere

## Context
Following up on branch-protecting.

I'd appreciate a careful eye on this, or a test run.  Once I run it, branch protections will be overwritten with no real history or ability to revert.  If we ever did something unique in a branch protection we won't be able to restore it easily.  

There's probably a way to determine the difference between existing rules and the to-be-applied protection ruleset, but in the interest of getting this done I want to punt that.

## Testing
Locally with `python update_branch_protections.py` against pcds-ci-test-repo-python
using subsets of the [branch protections spreadsheet](https://docs.google.com/spreadsheets/d/1y-AAYIK-8awg_SFIGygVQTrAV8KkGF1WJVzbKsLo450/edit?usp=sharing)

Example calls:
`python update_branch_protections.py -h`
`python update_branch_protections.py pcdshub pcds-test-repo-ci-python "Python Dev" --protect-master --protect-pages`
`python update_branch_protections.py --repo-data-path repo_list.csv --write`


<details><summary>example output</summary>
<p>


```bash
(pcds-5.7.3)roberttk@psbuild-rhel7-01:~/src/pcds-python-migration-tools(enh_apply_branch_prot +)$ python update_branch_protections.py --repo-data-path repo_list.csv 
{
  "environments": {
    "nodes": [
      {
        "id": "EN_kwDOIpSrvM4vTCfq",
        "name": "gh-pages",
        "protectionRules": {
          "nodes": []
        }
      },
      {
        "id": "EN_kwDOIpSrvM4vTPsP",
        "name": "github-pages",
        "protectionRules": {
          "nodes": [
            {
              "timeout": 0,
              "reviewers": {
                "nodes": []
              }
            }
          ]
        }
      }
    ]
  },
  "description": "Repository for testing PCDS's continuous integration tools (specifically pcds-ci-helpers)",
  "homepageUrl": "https://pcdshub.github.io/pcds-ci-test-repo-python",
  "name": "pcds-ci-test-repo-python",
  "nameWithOwner": "pcdshub/pcds-ci-test-repo-python",
  "isArchived": false,
  "id": "R_kgDOIpSrvA"
}
(dry run) Deleting branch protection setting
(dry run) Deleting branch protection setting
(dry run) Deleting branch protection setting
created master rule for repo: pcds-ci-test-repo-python
-- rule not applied
created gh_pages rule for repo: pcds-ci-test-repo-python
-- rule not applied
created default rule for repo: pcds-ci-test-repo-python
-- rule not applied
...
```

</p>
</details> 
