### PR TITLE
MNT: re-configure gh-pages branch to not restrict pushes

### DIFF
--- a/update_branch_protections.py
+++ b/update_branch_protections.py
@@ -18,6 +18,8 @@ gh_pages_prot = BranchProtection(
     requires_status_checks=False,
     required_approving_review_count=0,
     requires_approving_reviews=False,
+    restricts_pushes=False,
+    blocks_creations=False
 )
 all_prot = BranchProtection(
     pattern='*',


### PR DESCRIPTION
## Description

Sets "restrict pushes" to False for gh-pages, allowing our gha jobs to push documentation.  I mistakenly thought the "allows force pushes" setting would either supercede this rule.  

## Context and testing
pcdsdevices docs push failed, after removing this setting the job finished successfully ([job in question](https://github.com/pcdshub/pcdsdevices/actions/runs/6319770720/job/17185288214))
