### PR TITLE
MNT: unrestrict pushes by default (for pages and master)

### DIFF
--- a/graphql/branch_protection.graphql
+++ b/graphql/branch_protection.graphql
@@ -41,7 +41,7 @@ query showBranchProtection($owner:String!, $repo:String!) {
 mutation addBranchProtection(
     $repositoryId:ID!,
     $branchPattern:String!,
-    $requiredStatusChecks:[String!],
+    $requiredStatusCheckContexts:[String!],
     $allowsDeletions:Boolean!,
     $allowsForcePushes:Boolean!,
     $blocksCreations:Boolean!,
@@ -65,7 +65,7 @@ mutation addBranchProtection(
     requiresApprovingReviews: $requiresApprovingReviews
     requiredApprovingReviewCount: $requiredApprovingReviewCount
     requiresCodeOwnerReviews: $requiresCodeOwnerReviews
-    requiredStatusCheckContexts:$requiredStatusChecks
+    requiredStatusCheckContexts:$requiredStatusCheckContexts
     requiresStatusChecks: $requiresStatusChecks
     restrictsPushes: $restrictsPushes
     restrictsReviewDismissals: $restrictsReviewDismissals

--- a/update_branch_protections.py
+++ b/update_branch_protections.py
@@ -18,8 +18,6 @@ gh_pages_prot = BranchProtection(
     requires_status_checks=False,
     required_approving_review_count=0,
     requires_approving_reviews=False,
-    restricts_pushes=False,
-    blocks_creations=False
 )
 all_prot = BranchProtection(
     pattern='*',
@@ -28,7 +26,9 @@ all_prot = BranchProtection(
     requires_status_checks=False,
     required_approving_review_count=0,
     requires_approving_reviews=False,
-    allows_deletions=True
+    allows_deletions=True,
+    restricts_pushes=True,
+    blocks_creations=True
 )
 
 

--- a/update_github_settings.py
+++ b/update_github_settings.py
@@ -218,7 +218,7 @@ class BranchProtection(Serializable):
             get_packaged_graphql("branch_protection.graphql"),
             operationName="addBranchProtection",
             repositoryId=repo.id,
-            requiredStatusChecks=self.required_status_checks,
+            requiredStatusCheckContexts=self.required_status_checks,
             allowsDeletions=self.allows_deletions,
             allowsForcePushes=self.allows_force_pushes,
             blocksCreations=self.blocks_creations,

--- a/update_github_settings.py
+++ b/update_github_settings.py
@@ -203,8 +203,8 @@ class BranchProtection(Serializable):
     requires_status_checks: bool = field(
         default=True, metadata=alias("requiresStatusChecks")
     )
-    restricts_pushes: bool = field(default=True, metadata=alias("restrictsPushes"))
-    blocks_creations: bool = field(default=True, metadata=alias("blocksCreations"))
+    restricts_pushes: bool = field(default=False, metadata=alias("restrictsPushes"))
+    blocks_creations: bool = field(default=False, metadata=alias("blocksCreations"))
     restricts_review_dismissals: bool = field(
         default=False, metadata=alias("restrictsReviewDismissals")
     )


### PR DESCRIPTION
## Description

Only restrict pushes for default rule

## Context

This setting was preventing general members from merging pull requests (since they weren't allowed to push to master).

An alternate approach we might take is configuring teams and adding those teams to each repository as maintainers.  This would give us more granularity, allowing some members to merge PRs but not others.  
In a future where we start adding CODEOWNERS to repositories (which need teams to be manageable), this might make more sense.  The teams can be added by name to the restrict-pushes rule, and there is a [REST Endpoint](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions) for this (no graphql as far as I can tell)